### PR TITLE
Build pass fail notifications

### DIFF
--- a/cloudformation/build/deployment-pipeline.yaml
+++ b/cloudformation/build/deployment-pipeline.yaml
@@ -204,13 +204,8 @@ Resources:
       Environment:
         ComputeType: !Ref CodeBuildComputeType
         Image: "aws/codebuild/docker:1.12.1"
-        # Image: "aws/codebuild/java:openjdk-8"
-        # Image: "aws/codebuild/eb-java-8-amazonlinux-64:2.4.3"
-        # PrivilegedMode: true
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
-        #   - Name: AWS_REGION
-        #     Value: !Ref AWS::Region
           - Name: REPOSITORY_URI
             Value: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}"
           - Name: BRANCH
@@ -230,15 +225,9 @@ Resources:
         BuildSpec: buildspec.e2e.yml
       Environment:
         ComputeType: "BUILD_GENERAL1_SMALL"
-        # Image: !Ref CodeBuildProjectTestImage
         Image: "aws/codebuild/docker:1.12.1"
-        # Image: "aws/codebuild/java:openjdk-8"
-        # Image: "aws/codebuild/eb-java-8-amazonlinux-64:2.4.3"
-        # PrivilegedMode: true
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
-        #   - Name: AWS_REGION
-        #     Value: !Ref AWS::Region
           - Name: ENDPOINT_URI
             Value: !Sub "https://${Prefix}integration-${ApplicationName}.${PublicDomainName}"
           - Name: REPOSITORY_URI
@@ -493,10 +482,10 @@ Resources:
               RunOrder: 3
 
 
-  EventRule:
+  EventRuleBuild:
     Type: "AWS::Events::Rule"
     Properties:
-      Name: "TwigBuildNotifications"
+      Name: !Sub "${AppStackName}-${GitHubRepo}-${GitHubBranch}-build-rule"
       Description: "CloudWatch Event Rule to trap build status and send to SNS for eventual delivery to subscribers."
       EventPattern:
         source:
@@ -507,8 +496,8 @@ Resources:
           build-status:
             - SUCCEEDED
             - FAILED
-        project-name:
-          - !Ref CodeBuildProject
+          project-name:
+            - !Ref CodeBuildProject
       State: "ENABLED"
       Targets:
         - Arn:
@@ -516,10 +505,40 @@ Resources:
           Id: BuildResultsSns
           InputTransformer:
             InputPathsMap:
-              build-id: '$.detail.build-id'
-              project-name: '$.detail.project-name'
-              build-status: '$.detail.build-status'
-            InputTemplate: "Build <build-id>"
+              build-id: "$.detail.build-id"
+              project-name: "$.detail.project-name"
+              build-status: "$.detail.build-status"
+              build-log-link: "$.detail.additional-information.logs.deep-link"
+            InputTemplate: '"<project-name> build <build-status>.  Log:  <build-log-link>"'
+
+  EventRuleTest:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Sub "${AppStackName}-${GitHubRepo}-${GitHubBranch}-test-rule"
+      Description: "CloudWatch Event Rule to trap test status and send to SNS for eventual delivery to subscribers."
+      EventPattern:
+        source:
+          - "aws.codebuild"
+        detail-type:
+          - "CodeBuild Build State Change"
+        detail:
+          build-status:
+            - SUCCEEDED
+            - FAILED
+          project-name:
+            - !Ref CodeBuildProjectTest
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Fn::ImportValue: !Sub "${AWS::StackName}--SNS--Topic--build"
+          Id: BuildResultsSns
+          InputTransformer:
+            InputPathsMap:
+              build-id: "$.detail.build-id"
+              project-name: "$.detail.project-name"
+              build-status: "$.detail.build-status"
+              build-log-link: "$.detail.additional-information.logs.deep-link"
+            InputTemplate: '"<project-name> E2E test <build-status>.  Log:  <build-log-link>"'
 
   Sns:
     Type: AWS::CloudFormation::Stack

--- a/cloudformation/build/deployment-pipeline.yaml
+++ b/cloudformation/build/deployment-pipeline.yaml
@@ -492,6 +492,35 @@ Resources:
                 - Name: ProductionEnvironment
               RunOrder: 3
 
+
+  EventRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: "TwigBuildNotifications"
+      Description: "CloudWatch Event Rule to trap build status and send to SNS for eventual delivery to subscribers."
+      EventPattern:
+        source:
+          - "aws.codebuild"
+        detail-type:
+          - "CodeBuild Build State Change"
+        detail:
+          build-status:
+            - SUCCEEDED
+            - FAILED
+        project-name:
+          - !Ref CodeBuildProject
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Fn::ImportValue: !Sub "${AWS::StackName}--SNS--Topic--build"
+          Id: BuildResultsSns
+          InputTransformer:
+            InputPathsMap:
+              build-id: '$.detail.build-id'
+              project-name: '$.detail.project-name'
+              build-status: '$.detail.build-status'
+            InputTemplate: "Build <build-id>"
+
   Sns:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/cloudformation/build/sns.yaml
+++ b/cloudformation/build/sns.yaml
@@ -26,6 +26,22 @@ Resources:
     Properties:
       TopicName: !Sub "${ParentStackName}-${Purpose}-topic"
 
+  SnsTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Id: MyTopicPolicy
+        Version: '2012-10-17'
+        Statement:
+        - Sid: allow-cloudwatch-events
+          Effect: Allow
+          Principal:
+            Service: "events.amazonaws.com"
+          Action: sns:Publish
+          Resource: "*"
+      Topics:
+      - !Ref SnsTopic
+
   EmailSubscription:
     Type: "AWS::SNS::Subscription"
     Condition: EmailSpecified


### PR DESCRIPTION
This change posts build messages to SNS, and further, to whatever email address is configured in EMAIL_ADDRESS_BUILD environment variable.  If no address is configured, no subscription is created.